### PR TITLE
Remove application tag from manifest

### DIFF
--- a/readmoretextview/src/main/AndroidManifest.xml
+++ b/readmoretextview/src/main/AndroidManifest.xml
@@ -1,10 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.borjabravo.readmoretextview">
-
-    <application
-        android:allowBackup="true"
-        android:supportsRtl="true">
-
-    </application>
-
-</manifest>
+<manifest package="com.borjabravo.readmoretextview"/>


### PR DESCRIPTION
Removed the `<application>` tag in *AndroidManifest.xml* to suppress manifest merger issues when using this library.